### PR TITLE
fix: resolve bare issue numbers against correct repo when multiple remotes exist (#5)

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,5 +1,9 @@
 """Tests for issue parsing and text processing functions."""
 
+import subprocess
+from pathlib import Path
+
+import click
 import pytest
 
 from conftest import work
@@ -185,3 +189,399 @@ class TestParsedIssueDataclass:
         assert issue.owner == "anthropic"
         assert issue.repo == "claude"
         assert issue.number == 100
+
+
+class TestParseRemoteUrl:
+    """Tests for parse_remote_url function."""
+
+    def test_https_url_with_git_suffix(self):
+        assert work.parse_remote_url(
+            "https://github.com/owner/repo.git"
+        ) == ("github.com", "owner", "repo")
+
+    def test_https_url_without_git_suffix(self):
+        assert work.parse_remote_url(
+            "https://github.com/owner/repo"
+        ) == ("github.com", "owner", "repo")
+
+    def test_ssh_url(self):
+        assert work.parse_remote_url(
+            "git@github.com:owner/repo.git"
+        ) == ("github.com", "owner", "repo")
+
+    def test_netflix_ghe_https(self):
+        assert work.parse_remote_url(
+            "https://github.netflix.net/corp/project.git"
+        ) == ("github.netflix.net", "corp", "project")
+
+    def test_netflix_ghe_ssh(self):
+        assert work.parse_remote_url(
+            "git@github.netflix.net:corp/project.git"
+        ) == ("github.netflix.net", "corp", "project")
+
+    def test_http_url(self):
+        assert work.parse_remote_url(
+            "http://github.com/owner/repo.git"
+        ) == ("github.com", "owner", "repo")
+
+    def test_complex_repo_names(self):
+        assert work.parse_remote_url(
+            "https://github.com/my-org/my-cool-repo.git"
+        ) == ("github.com", "my-org", "my-cool-repo")
+
+    def test_non_github_host_returns_none(self):
+        assert work.parse_remote_url("https://gitlab.com/owner/repo.git") is None
+        assert work.parse_remote_url("https://bitbucket.org/owner/repo.git") is None
+
+    def test_invalid_url_returns_none(self):
+        assert work.parse_remote_url("not a url") is None
+        assert work.parse_remote_url("") is None
+
+    def test_trailing_whitespace_tolerated(self):
+        # Git remote output often has trailing whitespace/newline
+        assert work.parse_remote_url(
+            "https://github.com/owner/repo.git\n"
+        ) == ("github.com", "owner", "repo")
+
+
+def _init_git_repo_with_remotes(tmp_path: Path, remotes: dict[str, str]) -> Path:
+    """Create a tmp git repo with the given remotes. Returns the repo path.
+
+    Writes the remotes directly into .git/config to sidestep any global
+    git ``insteadOf`` URL rewrites on the host machine.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+    config_path = repo / ".git" / "config"
+    with open(config_path, "a") as f:
+        for name, url in remotes.items():
+            f.write(
+                f'[remote "{name}"]\n'
+                f'\turl = {url}\n'
+                f'\tfetch = +refs/heads/*:refs/remotes/{name}/*\n'
+            )
+    return repo
+
+
+class TestGetGitRemotes:
+    """Tests for get_git_remotes function."""
+
+    def test_no_remotes(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(tmp_path, {})
+        monkeypatch.chdir(repo)
+        assert work.get_git_remotes() == []
+
+    def test_single_remote(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        remotes = work.get_git_remotes()
+        assert remotes == [("origin", "github.com", "owner", "repo")]
+
+    def test_multiple_remotes_same_host(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.com/user/repo.git",
+                "upstream": "https://github.com/other/repo.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        remotes = work.get_git_remotes()
+        assert len(remotes) == 2
+        names = {r[0] for r in remotes}
+        assert names == {"origin", "upstream"}
+
+    def test_multiple_remotes_different_hosts(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.netflix.net/corp/proj.git",
+                "upstream": "https://github.com/posit-dev/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        remotes = work.get_git_remotes()
+        assert len(remotes) == 2
+        remotes_by_name = {r[0]: r for r in remotes}
+        assert remotes_by_name["origin"] == (
+            "origin", "github.netflix.net", "corp", "proj"
+        )
+        assert remotes_by_name["upstream"] == (
+            "upstream", "github.com", "posit-dev", "proj"
+        )
+
+    def test_ignores_non_github_remotes(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.com/owner/repo.git",
+                "other": "https://gitlab.com/owner/repo.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        remotes = work.get_git_remotes()
+        assert len(remotes) == 1
+        assert remotes[0][0] == "origin"
+
+    def test_dedupes_fetch_and_push(self, tmp_path, monkeypatch):
+        # `git remote -v` outputs each remote twice (fetch and push)
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        remotes = work.get_git_remotes()
+        # Should dedupe to a single entry
+        assert len(remotes) == 1
+
+
+class TestResolveTargetRepo:
+    """Tests for resolve_target_repo function."""
+
+    def test_single_remote_no_explicit(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        result = work.resolve_target_repo()
+        assert result == ("github.com", "owner", "repo")
+
+    def test_single_ghe_remote(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.netflix.net/corp/proj.git"},
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        result = work.resolve_target_repo()
+        assert result == ("github.netflix.net", "corp", "proj")
+
+    def test_multiple_remotes_same_host_prefers_origin(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "upstream": "https://github.com/upstream/proj.git",
+                "origin": "https://github.com/forker/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        result = work.resolve_target_repo()
+        assert result == ("github.com", "forker", "proj")
+
+    def test_multiple_hosts_errors_without_gh_host(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.netflix.net/corp/proj.git",
+                "upstream": "https://github.com/posit-dev/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        with pytest.raises(click.ClickException) as excinfo:
+            work.resolve_target_repo()
+        assert "multiple" in str(excinfo.value.message).lower()
+        assert "github.netflix.net" in excinfo.value.message
+        assert "github.com" in excinfo.value.message
+
+    def test_multiple_hosts_with_gh_host_picks_match(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.netflix.net/corp/proj.git",
+                "upstream": "https://github.com/posit-dev/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        result = work.resolve_target_repo(gh_host="github.netflix.net")
+        assert result == ("github.netflix.net", "corp", "proj")
+
+    def test_gh_host_with_no_matching_remote_errors(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        with pytest.raises(click.ClickException) as excinfo:
+            work.resolve_target_repo(gh_host="github.netflix.net")
+        assert "github.netflix.net" in excinfo.value.message
+
+    def test_explicit_repo_overrides_remote_detection(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.netflix.net/corp/proj.git",
+                "upstream": "https://github.com/posit-dev/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        # Explicit repo override avoids the ambiguity
+        result = work.resolve_target_repo(explicit_repo="posit-dev/proj")
+        assert result == (None, "posit-dev", "proj")
+
+    def test_explicit_repo_with_host_prefix(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        result = work.resolve_target_repo(
+            explicit_repo="github.netflix.net/corp/proj"
+        )
+        assert result == ("github.netflix.net", "corp", "proj")
+
+    def test_no_remotes_returns_none_without_explicit(self, tmp_path, monkeypatch):
+        repo = _init_git_repo_with_remotes(tmp_path, {})
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        assert work.resolve_target_repo() is None
+
+
+class TestParseIssueArgRepoScoped:
+    """Tests for parse_issue_arg with owner/repo:N syntax."""
+
+    def test_owner_repo_prefix(self):
+        issue, repo = work.parse_issue_arg("owner/repo:42")
+        assert issue == "42"
+        assert repo == "owner/repo"
+
+    def test_host_owner_repo_prefix(self):
+        issue, repo = work.parse_issue_arg("github.netflix.net/corp/proj:42")
+        assert issue == "42"
+        assert repo == "github.netflix.net/corp/proj"
+
+
+class TestSpawnInvocation:
+    """Tests for shell command building used by spawn_in_new_tab."""
+
+    def test_bare_issue_no_repo_flag(self, tmp_path):
+        cmd = work._build_work_invocation("42", tmp_path / "work")
+        assert "--here" in cmd
+        assert "42" in cmd
+        assert "--repo" not in cmd
+
+    def test_bare_issue_with_repo_override(self, tmp_path):
+        cmd = work._build_work_invocation(
+            "42", tmp_path / "work", repo_override="owner/name"
+        )
+        assert "--repo owner/name" in cmd
+        assert "--here 42" in cmd
+
+    def test_issue_with_shell_metachars_quoted(self, tmp_path):
+        # Inputs with shell metacharacters must be quoted; otherwise the
+        # child shell would interpret them.
+        cmd = work._build_work_invocation(
+            "feature; rm -rf /",
+            tmp_path / "work",
+        )
+        # shlex.quote wraps dangerous input in single quotes
+        assert "'feature; rm -rf /'" in cmd
+
+    def test_env_prefix_with_gh_host(self, monkeypatch):
+        monkeypatch.setenv("GH_HOST", "github.netflix.net")
+        prefix = work._build_spawn_env_prefix()
+        assert "GH_HOST=github.netflix.net" in prefix
+
+    def test_env_prefix_without_gh_host(self, monkeypatch):
+        monkeypatch.delenv("GH_HOST", raising=False)
+        prefix = work._build_spawn_env_prefix()
+        assert prefix == ""
+
+
+class TestValidateIssuesBeforeSpawn:
+    """Tests for the upfront issue validation that prevents spawning
+    workers against the wrong repo.
+    """
+
+    def test_ambiguous_remotes_without_disambiguator(
+        self, tmp_path, monkeypatch
+    ):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.netflix.net/corp/proj.git",
+                "upstream": "https://github.com/posit-dev/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        with pytest.raises(click.ClickException) as excinfo:
+            work.validate_issues_before_spawn(("42",))
+        # Message should mention ambiguity and show both hosts
+        assert "github.netflix.net" in excinfo.value.message
+        assert "github.com" in excinfo.value.message
+
+    def test_explicit_repo_override_resolves_cleanly(
+        self, tmp_path, monkeypatch, mocker
+    ):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {
+                "origin": "https://github.netflix.net/corp/proj.git",
+                "upstream": "https://github.com/posit-dev/proj.git",
+            },
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        # Mock fetch_issue_title to simulate a successful lookup
+        mocker.patch.object(
+            work, "fetch_issue_title", return_value="Mock issue title"
+        )
+        # Should not raise when an explicit repo disambiguates
+        work.validate_issues_before_spawn(
+            ("42",), repo_override="github.netflix.net/corp/proj"
+        )
+
+    def test_missing_issue_surfaces_in_error(
+        self, tmp_path, monkeypatch, mocker
+    ):
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        monkeypatch.delenv("GH_HOST", raising=False)
+        # Title lookup returns None (issue doesn't exist)
+        mocker.patch.object(work, "fetch_issue_title", return_value=None)
+        with pytest.raises(click.ClickException) as excinfo:
+            work.validate_issues_before_spawn(("42",))
+        assert "42" in excinfo.value.message
+        assert "github.com/owner/repo" in excinfo.value.message
+
+    def test_jira_keys_are_skipped(self, tmp_path, monkeypatch, mocker):
+        # JIRA keys shouldn't be validated against GitHub
+        repo = _init_git_repo_with_remotes(tmp_path, {})
+        monkeypatch.chdir(repo)
+        mock_fetch = mocker.patch.object(
+            work, "fetch_issue_title", return_value="title"
+        )
+        work.validate_issues_before_spawn(("AIE-123",))
+        mock_fetch.assert_not_called()
+
+    def test_url_validated_against_url_host(
+        self, tmp_path, monkeypatch, mocker
+    ):
+        # A full URL should be validated against its URL's host, not the
+        # repo's git remotes
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/different/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        mock_fetch = mocker.patch.object(
+            work, "fetch_issue_title", return_value="title"
+        )
+        work.validate_issues_before_spawn(
+            ("https://github.netflix.net/corp/proj/issues/5",)
+        )
+        # fetch_issue_title should be called with host-prefixed repo
+        call_kwargs = mock_fetch.call_args
+        assert call_kwargs.kwargs.get("repo") == "github.netflix.net/corp/proj"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -483,6 +483,19 @@ class TestResolveTargetRepo:
         monkeypatch.delenv("GH_HOST", raising=False)
         assert work.resolve_target_repo() is None
 
+    def test_malformed_explicit_repo_errors(self, tmp_path, monkeypatch):
+        # Empty segments (``owner//name``) or too many / too few slashes
+        # should raise a clear error rather than producing a malformed
+        # downstream target.
+        repo = _init_git_repo_with_remotes(
+            tmp_path, {"origin": "https://github.com/owner/repo.git"}
+        )
+        monkeypatch.chdir(repo)
+        for bad in ("owner//name", "just-one-segment", "a/b/c/d"):
+            with pytest.raises(click.ClickException) as excinfo:
+                work.resolve_target_repo(explicit_repo=bad)
+            assert "Invalid --repo" in excinfo.value.message
+
 
 class TestParseIssueArgRepoScoped:
     """Tests for parse_issue_arg with owner/repo:N syntax."""

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -256,6 +256,19 @@ class TestParseRemoteUrl:
         assert work.parse_remote_url("https://gitlab.com/owner/repo.git") is None
         assert work.parse_remote_url("https://bitbucket.org/owner/repo.git") is None
 
+    def test_lookalike_github_host_rejected(self):
+        # Substring-like hostnames must NOT be accepted — the allowlist
+        # requires an exact match or a subdomain of an allowed host.
+        assert work.parse_remote_url(
+            "https://notgithub.com/owner/repo.git"
+        ) is None
+        assert work.parse_remote_url(
+            "https://github.com.attacker.net/owner/repo.git"
+        ) is None
+        assert work.parse_remote_url(
+            "https://mygithub.corp.example/owner/repo.git"
+        ) is None
+
     def test_invalid_url_returns_none(self):
         assert work.parse_remote_url("not a url") is None
         assert work.parse_remote_url("") is None
@@ -559,10 +572,12 @@ class TestSpawnInvocation:
         assert '\\"' in escaped
         assert "\\\\" in escaped
         # The escaped form must not contain an unescaped "
-        # (i.e. every " in the escaped string is preceded by \)
+        # (i.e. every " in the escaped string is preceded by \).
+        # Guard ``i > 0`` so a leading ``"`` (which would wrap to index -1)
+        # still counts as unescaped instead of silently passing.
         for i, ch in enumerate(escaped):
             if ch == '"':
-                assert escaped[i - 1] == "\\"
+                assert i > 0 and escaped[i - 1] == "\\"
 
 
 class TestValidateIssuesBeforeSpawn:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -350,15 +350,16 @@ class TestGetGitRemotes:
         assert len(remotes) == 1
         assert remotes[0][0] == "origin"
 
-    def test_dedupes_fetch_and_push(self, tmp_path, monkeypatch):
-        # `git remote -v` outputs each remote twice (fetch and push)
+    def test_one_entry_per_remote(self, tmp_path, monkeypatch):
+        # Underlying ``git config --get-regexp remote\..*\.url`` emits a
+        # single line per remote (unlike ``git remote -v`` which prints
+        # fetch+push). Guard against regression if this is ever rewritten.
         repo = _init_git_repo_with_remotes(
             tmp_path,
             {"origin": "https://github.com/owner/repo.git"},
         )
         monkeypatch.chdir(repo)
         remotes = work.get_git_remotes()
-        # Should dedupe to a single entry
         assert len(remotes) == 1
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -534,6 +534,23 @@ class TestSpawnInvocation:
         prefix = work._build_spawn_env_prefix()
         assert prefix == ""
 
+    def test_applescript_escape_doubles_quotes_and_backslashes(self):
+        # `shlex.quote` wraps values with single quotes that embed
+        # literal double quotes (e.g. `'O'"'"'Brian'`). Those double
+        # quotes must be escaped before being dropped into an
+        # AppleScript `write text "..."` literal, or the string ends
+        # early.
+        raw = "echo 'O'\"'\"'Brian' && path\\with\\backslash"
+        escaped = work._escape_for_applescript(raw)
+        # Double quotes are preceded by a backslash, backslashes are doubled
+        assert '\\"' in escaped
+        assert "\\\\" in escaped
+        # The escaped form must not contain an unescaped "
+        # (i.e. every " in the escaped string is preceded by \)
+        for i, ch in enumerate(escaped):
+            if ch == '"':
+                assert escaped[i - 1] == "\\"
+
 
 class TestValidateIssuesBeforeSpawn:
     """Tests for the upfront issue validation that prevents spawning

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -121,6 +121,20 @@ class TestParseIssueArg:
         assert issue == "https://github.com/owner/repo/issues/1"
         assert repo is None
 
+    def test_feature_description_with_colon_not_split(self):
+        # Descriptions like "fix: some text" have colons but shouldn't be
+        # parsed as repo-scoped — the suffix isn't numeric.
+        issue, repo = work.parse_issue_arg("fix: the auth bug")
+        assert issue == "fix: the auth bug"
+        assert repo is None
+
+    def test_repo_prefix_requires_numeric_suffix(self):
+        # ``repo:something-non-numeric`` is also treated as a description,
+        # not a repo-scoped issue spec.
+        issue, repo = work.parse_issue_arg("repo:abc")
+        assert issue == "repo:abc"
+        assert repo is None
+
 
 class TestSlugify:
     """Tests for slugify function."""
@@ -444,6 +458,21 @@ class TestResolveTargetRepo:
         monkeypatch.chdir(repo)
         result = work.resolve_target_repo(
             explicit_repo="github.netflix.net/corp/proj"
+        )
+        assert result == ("github.netflix.net", "corp", "proj")
+
+    def test_explicit_repo_without_host_uses_gh_host(self, tmp_path, monkeypatch):
+        # When --repo has only owner/name and GH_HOST is set, the host
+        # hint from env should be preserved so downstream gh calls go to
+        # the intended host.
+        repo = _init_git_repo_with_remotes(
+            tmp_path,
+            {"origin": "https://github.com/owner/repo.git"},
+        )
+        monkeypatch.chdir(repo)
+        result = work.resolve_target_repo(
+            gh_host="github.netflix.net",
+            explicit_repo="corp/proj",
         )
         assert result == ("github.netflix.net", "corp", "proj")
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -229,6 +229,15 @@ class TestParseRemoteUrl:
             "https://github.com/my-org/my-cool-repo.git"
         ) == ("github.com", "my-org", "my-cool-repo")
 
+    def test_repo_name_with_dots(self):
+        # GitHub allows dots in repo names
+        assert work.parse_remote_url(
+            "https://github.com/owner/foo.bar.git"
+        ) == ("github.com", "owner", "foo.bar")
+        assert work.parse_remote_url(
+            "git@github.com:owner/foo.bar.baz.git"
+        ) == ("github.com", "owner", "foo.bar.baz")
+
     def test_non_github_host_returns_none(self):
         assert work.parse_remote_url("https://gitlab.com/owner/repo.git") is None
         assert work.parse_remote_url("https://bitbucket.org/owner/repo.git") is None
@@ -585,3 +594,31 @@ class TestValidateIssuesBeforeSpawn:
         # fetch_issue_title should be called with host-prefixed repo
         call_kwargs = mock_fetch.call_args
         assert call_kwargs.kwargs.get("repo") == "github.netflix.net/corp/proj"
+
+    def test_repo_flag_with_non_numeric_errors(self, tmp_path, monkeypatch):
+        # `work --repo owner/name "some text"` is a user error — the repo
+        # flag only makes sense with a numeric issue. The validator must
+        # surface this BEFORE spawning so it fails in the same place as
+        # the child `work --here` would.
+        repo = _init_git_repo_with_remotes(
+            tmp_path, {"origin": "https://github.com/owner/repo.git"}
+        )
+        monkeypatch.chdir(repo)
+        with pytest.raises(click.ClickException) as excinfo:
+            work.validate_issues_before_spawn(
+                ("not-a-number",), repo_override="owner/name"
+            )
+        assert "numeric issue number" in excinfo.value.message
+
+    def test_plain_description_skipped(self, tmp_path, monkeypatch, mocker):
+        # Without --repo/prefix, non-numeric input is a feature
+        # description and should be passed through without validation.
+        repo = _init_git_repo_with_remotes(
+            tmp_path, {"origin": "https://github.com/owner/repo.git"}
+        )
+        monkeypatch.chdir(repo)
+        mock_fetch = mocker.patch.object(
+            work, "fetch_issue_title", return_value="title"
+        )
+        work.validate_issues_before_spawn(("add dark mode",))
+        mock_fetch.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -5,64 +5,64 @@ requires-python = ">=3.11"
 [[package]]
 name = "click"
 version = "8.3.1"
-source = { registry = "https://pypi.netflix.net/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://pypi.netflix.net/packages/19343417910/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/19343417909/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.netflix.net/simple" }
-sdist = { url = "https://pypi.netflix.net/packages/988988/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/988987/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi.netflix.net/simple" }
-sdist = { url = "https://pypi.netflix.net/packages/19216517185/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/19216517184/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
-source = { registry = "https://pypi.netflix.net/simple" }
-sdist = { url = "https://pypi.netflix.net/packages/18622031468/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/18622031467/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.netflix.net/simple" }
-sdist = { url = "https://pypi.netflix.net/packages/18687957487/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/18687957486/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
-source = { registry = "https://pypi.netflix.net/simple" }
-sdist = { url = "https://pypi.netflix.net/packages/18805843371/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/18805843370/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
 name = "pytest"
 version = "9.0.2"
-source = { registry = "https://pypi.netflix.net/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -70,75 +70,75 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://pypi.netflix.net/packages/19434856402/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/19434856401/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
 name = "pytest-mock"
 version = "3.15.1"
-source = { registry = "https://pypi.netflix.net/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://pypi.netflix.net/packages/19091085625/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/19091085624/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]
 name = "tomli"
 version = "2.4.0"
-source = { registry = "https://pypi.netflix.net/simple" }
-sdist = { url = "https://pypi.netflix.net/packages/19585910318/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
 wheels = [
-    { url = "https://pypi.netflix.net/packages/19585909822/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
-    { url = "https://pypi.netflix.net/packages/19585909823/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
-    { url = "https://pypi.netflix.net/packages/19585909824/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
-    { url = "https://pypi.netflix.net/packages/19585909825/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
-    { url = "https://pypi.netflix.net/packages/19585909826/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
-    { url = "https://pypi.netflix.net/packages/19585909827/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
-    { url = "https://pypi.netflix.net/packages/19585909828/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
-    { url = "https://pypi.netflix.net/packages/19585909829/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
-    { url = "https://pypi.netflix.net/packages/19585909830/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
-    { url = "https://pypi.netflix.net/packages/19585909831/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
-    { url = "https://pypi.netflix.net/packages/19585909832/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
-    { url = "https://pypi.netflix.net/packages/19585909833/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
-    { url = "https://pypi.netflix.net/packages/19585909834/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
-    { url = "https://pypi.netflix.net/packages/19585909972/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
-    { url = "https://pypi.netflix.net/packages/19585909973/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
-    { url = "https://pypi.netflix.net/packages/19585909974/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
-    { url = "https://pypi.netflix.net/packages/19585909975/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
-    { url = "https://pypi.netflix.net/packages/19585909976/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
-    { url = "https://pypi.netflix.net/packages/19585909977/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
-    { url = "https://pypi.netflix.net/packages/19585909978/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
-    { url = "https://pypi.netflix.net/packages/19585909979/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
-    { url = "https://pypi.netflix.net/packages/19585909980/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
-    { url = "https://pypi.netflix.net/packages/19585909981/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
-    { url = "https://pypi.netflix.net/packages/19585909982/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
-    { url = "https://pypi.netflix.net/packages/19585909983/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
-    { url = "https://pypi.netflix.net/packages/19585909984/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
-    { url = "https://pypi.netflix.net/packages/19585910135/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
-    { url = "https://pypi.netflix.net/packages/19585910136/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
-    { url = "https://pypi.netflix.net/packages/19585910137/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
-    { url = "https://pypi.netflix.net/packages/19585910138/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
-    { url = "https://pypi.netflix.net/packages/19585910139/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
-    { url = "https://pypi.netflix.net/packages/19585910140/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
-    { url = "https://pypi.netflix.net/packages/19585910141/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
-    { url = "https://pypi.netflix.net/packages/19585910142/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
-    { url = "https://pypi.netflix.net/packages/19585910143/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
-    { url = "https://pypi.netflix.net/packages/19585910144/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
-    { url = "https://pypi.netflix.net/packages/19585910145/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
-    { url = "https://pypi.netflix.net/packages/19585910146/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
-    { url = "https://pypi.netflix.net/packages/19585910147/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
-    { url = "https://pypi.netflix.net/packages/19585910311/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
-    { url = "https://pypi.netflix.net/packages/19585910312/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
-    { url = "https://pypi.netflix.net/packages/19585910313/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
-    { url = "https://pypi.netflix.net/packages/19585910314/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
-    { url = "https://pypi.netflix.net/packages/19585910315/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
-    { url = "https://pypi.netflix.net/packages/19585910316/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
-    { url = "https://pypi.netflix.net/packages/19585910317/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]

--- a/work
+++ b/work
@@ -1175,6 +1175,7 @@ def validate_issues_before_spawn(
     gh_host = os.environ.get("GH_HOST")
     failures: list[str] = []
     resolved_repos: set[str] = set()
+    validated_count = 0
 
     for raw in issues:
         # Skip obvious non-GitHub inputs
@@ -1195,6 +1196,7 @@ def validate_issues_before_spawn(
                 )
             else:
                 resolved_repos.add(target)
+                validated_count += 1
             continue
 
         # Bare number or owner/name:N / host/owner/name:N
@@ -1237,6 +1239,7 @@ def validate_issues_before_spawn(
             )
         else:
             resolved_repos.add(target)
+            validated_count += 1
 
     if failures:
         repo_list = (
@@ -1251,9 +1254,9 @@ def validate_issues_before_spawn(
             "repo, or set GH_HOST to disambiguate."
         )
 
-    if resolved_repos:
+    if validated_count:
         click.echo(
-            f"Validated {len(issues)} issue(s) against: "
+            f"Validated {validated_count} issue(s) against: "
             f"{', '.join(sorted(resolved_repos))}"
         )
 
@@ -3221,6 +3224,7 @@ def run_here(
     jira_key: Optional[str] = None
     branch_name: Optional[str] = None
     issue_source = "github"
+    gh_cli: Optional[str] = None  # Set in each code path below
 
     # Try JIRA first (if acli available), then GitHub
     jira_key = parse_jira_key(input_str)
@@ -3322,8 +3326,9 @@ def run_here(
             branch_name = f"feature-{slugify(description)}"
             click.echo(f"Will create feature branch: {branch_name}")
 
-    # gh_cli for downstream code paths when we don't have a host yet
-    if 'gh_cli' not in locals():
+    # Fall back to remote-based CLI detection for JIRA/description paths
+    # where no GitHub host was resolved above.
+    if gh_cli is None:
         gh_cli = detect_gh_cli(input_str)
 
     if not branch_name:

--- a/work
+++ b/work
@@ -728,12 +728,12 @@ def resolve_target_repo(
     # Explicit repo override always wins
     if explicit_repo:
         parts = explicit_repo.strip("/").split("/")
-        if len(parts) == 2:
+        if all(parts) and len(parts) == 2:
             # No host segment — fall back to GH_HOST if the caller set it,
             # so an explicit repo combined with an explicit host still
             # reaches the right API.
             return gh_host, parts[0], parts[1]
-        if len(parts) == 3:
+        if all(parts) and len(parts) == 3:
             return parts[0], parts[1], parts[2]
         raise click.ClickException(
             f"Invalid --repo value {explicit_repo!r}. "

--- a/work
+++ b/work
@@ -667,8 +667,11 @@ def parse_remote_url(url: str) -> Optional[tuple[str, str, str]]:
         return None
 
     host = match.group(1)
-    # Only recognize known GitHub hosts
-    if 'github' not in host:
+    # Allowlist of GitHub hosts — anything else is out of scope for
+    # auto-detection. Users on custom GHE hosts can still pass an
+    # explicit ``--repo host/owner/name`` or a full issue URL.
+    allowed = ("github.com", "github.netflix.net")
+    if not any(host == h or host.endswith("." + h) for h in allowed):
         return None
     return host, match.group(2), match.group(3)
 
@@ -1195,8 +1198,11 @@ def validate_issues_before_spawn(
 
         parsed_url = parse_github_url(raw)
         if parsed_url:
+            # ``parse_github_url`` already required a valid https?:// host,
+            # so this match is guaranteed to succeed.
             url_host_match = re.match(r'https?://(?:www\.)?([^/]+)', raw)
-            host = url_host_match.group(1) if url_host_match else "github.com"
+            assert url_host_match, f"parse_github_url accepted URL without host: {raw}"
+            host = url_host_match.group(1)
             target = f"{host}/{parsed_url.owner}/{parsed_url.repo}"
             gh_cli = detect_gh_cli(f"https://{host}/")
             title = fetch_issue_title(parsed_url.number, gh_cli, repo=target)

--- a/work
+++ b/work
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import re
 import json
+import shlex
 import signal
 import sqlite3
 import subprocess
@@ -626,12 +627,151 @@ def parse_issue_arg(input_str: str) -> tuple[str, Optional[str]]:
     """
     Parse issue argument with optional repo prefix.
     Returns (issue, repo) tuple where repo may be None.
-    Supports: 42, repo:42, AIE-123
+    Supports: 42, repo:42, owner/repo:42, host/owner/repo:42, AIE-123
     """
     if ":" in input_str and not input_str.startswith("http"):
         repo, issue = input_str.split(":", 1)
         return issue, repo
     return input_str, None
+
+
+def parse_remote_url(url: str) -> Optional[tuple[str, str, str]]:
+    """Parse a git remote URL into (host, owner, repo).
+
+    Supports HTTPS and SSH URL forms for github.com and
+    github.netflix.net. Returns None for other hosts or invalid input.
+    """
+    if not url:
+        return None
+    url = url.strip()
+
+    # HTTPS: https://host/owner/repo(.git)?
+    https_match = re.match(
+        r'https?://([^/]+)/([^/]+)/([^/.\s]+?)(?:\.git)?/?$',
+        url,
+    )
+    # SSH: git@host:owner/repo(.git)?
+    ssh_match = re.match(
+        r'(?:ssh://)?git@([^:/]+)[:/]([^/]+)/([^/.\s]+?)(?:\.git)?/?$',
+        url,
+    )
+    match = https_match or ssh_match
+    if not match:
+        return None
+
+    host = match.group(1)
+    # Only recognize known GitHub hosts
+    if 'github' not in host:
+        return None
+    return host, match.group(2), match.group(3)
+
+
+def get_git_remotes() -> list[tuple[str, str, str, str]]:
+    """Return git remotes as list of (name, host, owner, repo).
+
+    Reads raw URLs from git config so ``url.<base>.insteadOf`` rewrites
+    do not mask the actual host the user configured. Filters out
+    non-GitHub remotes. Returns an empty list if not in a git repo or
+    git errors out.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get-regexp", r"^remote\..*\.url$"],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    remotes: list[tuple[str, str, str, str]] = []
+    for line in result.stdout.strip().split('\n'):
+        if not line:
+            continue
+        key, _, url = line.partition(' ')
+        match = re.match(r'^remote\.(.+)\.url$', key)
+        if not match:
+            continue
+        name = match.group(1)
+        parsed = parse_remote_url(url)
+        if parsed:
+            host, owner, repo = parsed
+            remotes.append((name, host, owner, repo))
+    return remotes
+
+
+def resolve_target_repo(
+    gh_host: Optional[str] = None,
+    explicit_repo: Optional[str] = None,
+) -> Optional[tuple[Optional[str], str, str]]:
+    """Resolve the repo a bare issue number should target.
+
+    Returns (host, owner, repo) where host may be None when explicit_repo
+    has no host prefix. Returns None when not in a git repo and no
+    explicit_repo is given.
+
+    Priority:
+    1. explicit_repo (from --repo or repo:N syntax) wins over detection.
+    2. gh_host (from env) picks the matching remote when set.
+    3. Otherwise, use git remotes. If remotes span multiple hosts and no
+       disambiguator is provided, raise ClickException with guidance.
+
+    Args:
+        gh_host: Value of GH_HOST env var, or None.
+        explicit_repo: "owner/name" or "host/owner/name" from user.
+    """
+    # Explicit repo override always wins
+    if explicit_repo:
+        parts = explicit_repo.strip("/").split("/")
+        if len(parts) == 2:
+            return None, parts[0], parts[1]
+        if len(parts) == 3:
+            return parts[0], parts[1], parts[2]
+        raise click.ClickException(
+            f"Invalid --repo value {explicit_repo!r}. "
+            f"Expected owner/name or host/owner/name."
+        )
+
+    remotes = get_git_remotes()
+    if not remotes:
+        return None
+
+    # GH_HOST pins the host when set
+    if gh_host:
+        matching = [r for r in remotes if r[1] == gh_host]
+        if not matching:
+            hosts = sorted({r[1] for r in remotes})
+            raise click.ClickException(
+                f"GH_HOST={gh_host} but no git remote matches that host.\n"
+                f"Remotes found on: {', '.join(hosts)}\n"
+                f"Either unset GH_HOST, add a matching remote, or pass "
+                f"--repo owner/name."
+            )
+        # Prefer origin among matches, else first
+        origin = next((r for r in matching if r[0] == 'origin'), None)
+        _, host, owner, repo = origin or matching[0]
+        return host, owner, repo
+
+    # No GH_HOST: check for cross-host ambiguity
+    hosts = {r[1] for r in remotes}
+    if len(hosts) > 1:
+        remote_descs = "\n".join(
+            f"  {name}: https://{host}/{owner}/{repo}"
+            for name, host, owner, repo in remotes
+        )
+        raise click.ClickException(
+            "Multiple git remotes on different hosts detected; bare "
+            "issue numbers are ambiguous:\n"
+            f"{remote_descs}\n\n"
+            "Disambiguate with one of:\n"
+            "  - Set GH_HOST=<host> to pick the remote on that host\n"
+            "  - Pass --repo owner/name (or host/owner/name) to work\n"
+            "  - Prefix the number with the repo (e.g. 'owner/name:42')\n"
+            "  - Pass a full issue URL instead"
+        )
+
+    # Single host: prefer origin, else first remote
+    origin = next((r for r in remotes if r[0] == 'origin'), None)
+    _, host, owner, repo = origin or remotes[0]
+    return host, owner, repo
 
 
 def get_repo_root() -> Optional[Path]:
@@ -912,9 +1052,39 @@ def detect_spawn_method() -> Optional[str]:
     return None
 
 
-def spawn_iterm2(issue: str, script_path: Path, cwd: Path) -> None:
+def _build_spawn_env_prefix() -> str:
+    """Build an ``env KEY=VAL`` prefix that forwards work-relevant env vars
+    (currently just GH_HOST) into the spawned terminal tab so child gh
+    calls honor the same host selection as the parent.
+    """
+    parts = []
+    gh_host = os.environ.get("GH_HOST")
+    if gh_host:
+        parts.append(f"GH_HOST={shlex.quote(gh_host)}")
+    return " ".join(parts)
+
+
+def _build_work_invocation(
+    issue: str,
+    script_path: Path,
+    repo_override: Optional[str] = None,
+) -> str:
+    """Build the ``work --here`` shell invocation, forwarding flags."""
+    repo_flag = f" --repo {shlex.quote(repo_override)}" if repo_override else ""
+    return f"'{script_path}'{repo_flag} --here {shlex.quote(issue)}"
+
+
+def spawn_iterm2(
+    issue: str,
+    script_path: Path,
+    cwd: Path,
+    repo_override: Optional[str] = None,
+) -> None:
     """Spawn a new iTerm2 tab with the work command."""
-    cmd = f"cd '{cwd}' && '{script_path}' --here '{issue}'"
+    env_prefix = _build_spawn_env_prefix()
+    env_str = f"{env_prefix} " if env_prefix else ""
+    invocation = _build_work_invocation(issue, script_path, repo_override)
+    cmd = f"cd {shlex.quote(str(cwd))} && {env_str}{invocation}"
 
     applescript = f'''
 tell application "iTerm2"
@@ -929,12 +1099,20 @@ end tell
     subprocess.run(["osascript", "-e", applescript], check=True)
 
 
-def spawn_wsl(issue: str, script_path: Path, cwd: Path) -> None:
+def spawn_wsl(
+    issue: str,
+    script_path: Path,
+    cwd: Path,
+    repo_override: Optional[str] = None,
+) -> None:
     """Spawn a new Windows Terminal tab via WSL."""
     distro = os.environ.get("WSL_DISTRO_NAME", "Ubuntu")
     shell = os.path.basename(os.environ.get("SHELL", "/bin/bash"))
 
-    cmd = f"cd '{cwd}' && '{script_path}' --here '{issue}'"
+    env_prefix = _build_spawn_env_prefix()
+    env_str = f"{env_prefix} " if env_prefix else ""
+    invocation = _build_work_invocation(issue, script_path, repo_override)
+    cmd = f"cd {shlex.quote(str(cwd))} && {env_str}{invocation}"
 
     # Find wt.exe
     import glob
@@ -950,7 +1128,7 @@ def spawn_wsl(issue: str, script_path: Path, cwd: Path) -> None:
     ], check=True)
 
 
-def spawn_in_new_tab(issue: str) -> None:
+def spawn_in_new_tab(issue: str, repo_override: Optional[str] = None) -> None:
     """Spawn work command in a new terminal tab."""
     method = detect_spawn_method()
     if not method:
@@ -963,9 +1141,100 @@ def spawn_in_new_tab(issue: str) -> None:
     cwd = Path.cwd()
 
     if method == "iterm2":
-        spawn_iterm2(issue, script_path, cwd)
+        spawn_iterm2(issue, script_path, cwd, repo_override)
     elif method == "wsl":
-        spawn_wsl(issue, script_path, cwd)
+        spawn_wsl(issue, script_path, cwd, repo_override)
+
+
+def validate_issues_before_spawn(
+    issues: tuple, repo_override: Optional[str] = None
+) -> None:
+    """Resolve each GitHub issue against its target repo before spawning.
+
+    Bails with a clear error if any issue can't be resolved, so workers
+    aren't spawned against the wrong repo. JIRA keys and feature
+    descriptions are skipped (they don't need cross-remote resolution).
+
+    Raises:
+        click.ClickException: If any issue resolves to a non-existent
+            issue or the repo can't be determined.
+    """
+    gh_host = os.environ.get("GH_HOST")
+    failures: list[str] = []
+    resolved_repos: set[str] = set()
+
+    for raw in issues:
+        # Skip obvious non-GitHub inputs
+        if parse_jira_key(raw):
+            continue
+
+        parsed_url = parse_github_url(raw)
+        if parsed_url:
+            url_host_match = re.match(r'https?://(?:www\.)?([^/]+)', raw)
+            host = url_host_match.group(1) if url_host_match else "github.com"
+            target = f"{host}/{parsed_url.owner}/{parsed_url.repo}"
+            gh_cli = detect_gh_cli(f"https://{host}/")
+            title = fetch_issue_title(parsed_url.number, gh_cli, repo=target)
+            if title is None:
+                failures.append(
+                    f"  {raw}: could not fetch issue {parsed_url.number} "
+                    f"from {target}"
+                )
+            else:
+                resolved_repos.add(target)
+            continue
+
+        # Bare number or owner/name:N / host/owner/name:N
+        issue_token, inline_repo = parse_issue_arg(raw)
+        if not issue_token.isdigit():
+            # Not a number and not URL/JIRA → description; skip
+            continue
+
+        effective_repo = repo_override or inline_repo
+        try:
+            resolved = resolve_target_repo(
+                gh_host=gh_host, explicit_repo=effective_repo
+            )
+        except click.ClickException as e:
+            # Ambiguous remotes or missing matching host: surface once
+            raise click.ClickException(
+                f"Cannot resolve issue {raw!r}:\n{e.message}"
+            )
+        if not resolved:
+            failures.append(
+                f"  {raw}: no git remote found and no --repo provided"
+            )
+            continue
+
+        host, owner, repo = resolved
+        target = f"{host}/{owner}/{repo}" if host else f"{owner}/{repo}"
+        gh_cli = detect_gh_cli(f"https://{host}/" if host else None)
+        title = fetch_issue_title(int(issue_token), gh_cli, repo=target)
+        if title is None:
+            failures.append(
+                f"  {raw}: issue #{issue_token} not found in {target}"
+            )
+        else:
+            resolved_repos.add(target)
+
+    if failures:
+        repo_list = (
+            "\n\nResolved against:\n  " + "\n  ".join(sorted(resolved_repos))
+            if resolved_repos else ""
+        )
+        raise click.ClickException(
+            "Could not validate one or more issues before spawning:\n"
+            + "\n".join(failures)
+            + repo_list
+            + "\n\nPass --repo owner/name or a full URL to pin the target "
+            "repo, or set GH_HOST to disambiguate."
+        )
+
+    if resolved_repos:
+        click.echo(
+            f"Validated {len(issues)} issue(s) against: "
+            f"{', '.join(sorted(resolved_repos))}"
+        )
 
 
 def spawn_resume_iterm2(session_id: str, worktree_path: Path, worker_id: int) -> None:
@@ -1268,11 +1537,13 @@ def extract_plan_name(plan_path: str) -> str:
 @click.option('--cleanup', 'do_cleanup', is_flag=True, help='Find and kill orphaned claude processes')
 @click.option('--force', 'force', is_flag=True, help='Skip confirmation prompts (for --cleanup)')
 @click.option('--plan', 'plan_file', type=click.Path(exists=True), help='Execute a plan file in a new worker')
+@click.option('--repo', 'repo_override',
+              help='Target repo for bare issue numbers: owner/name or host/owner/name')
 @click.pass_context
 def cli(ctx, issues, here, show_status, show_events, show_logs, do_stop, do_send,
         show_messages, peek, quiet, set_stage, mark_done, set_pr, log_event, transition, msg_type,
         do_init, no_ai, do_review, pre_merge, dry_run, show_reviews, do_resume, do_cleanup, force,
-        plan_file):
+        plan_file, repo_override):
     """
     Start Claude Code session(s) for GitHub issue(s) or JIRA tickets.
 
@@ -1284,6 +1555,14 @@ def cli(ctx, issues, here, show_status, show_events, show_logs, do_stop, do_send
       work "add dark mode support"      # New feature branch
       work AIE-123                       # JIRA issue
       work --plan docs/plans/my-plan.md # Execute a plan file
+
+    \b
+    Disambiguating the target repo (when you have multiple remotes):
+      work --repo owner/name 4 5 6     # Pin all issues to owner/name
+      work --repo host/owner/name 42   # Include host when needed
+      work owner/name:42               # Inline prefix on a single issue
+      work host/owner/name:42          # With host prefix
+      GH_HOST=github.netflix.net work 42  # Pick the matching remote
 
     \b
     Config & Review:
@@ -1409,13 +1688,17 @@ def cli(ctx, issues, here, show_status, show_events, show_logs, do_stop, do_send
     if here:
         # Run in current terminal
         description = issues[1] if len(issues) > 1 else None
-        run_here(issues[0], description)
+        run_here(issues[0], description, repo_override=repo_override)
     else:
+        # Validate issues upfront before spawning any tabs (fast fail on
+        # ambiguous-remote / missing-issue / wrong-repo mismatches).
+        validate_issues_before_spawn(issues, repo_override)
+
         # Spawn in new tabs
         for i, issue in enumerate(issues):
             if i > 0:
                 time.sleep(config.spawn_delay)
-            spawn_in_new_tab(issue)
+            spawn_in_new_tab(issue, repo_override=repo_override)
             click.echo(f"Spawned worker for: {issue}")
 
 
@@ -2887,8 +3170,18 @@ end tell
         ], check=True)
 
 
-def run_here(input_str: str, description: Optional[str] = None):
-    """Run worker in current terminal."""
+def run_here(
+    input_str: str,
+    description: Optional[str] = None,
+    repo_override: Optional[str] = None,
+):
+    """Run worker in current terminal.
+
+    Args:
+        input_str: Issue number, URL, JIRA key, or owner/name:N / host/owner/name:N.
+        description: Optional description override.
+        repo_override: Optional owner/name or host/owner/name from --repo CLI flag.
+    """
     repo_root = get_repo_root()
     if not repo_root:
         raise click.ClickException("Not in a git repository")
@@ -2896,14 +3189,14 @@ def run_here(input_str: str, description: Optional[str] = None):
     # Use main repo name for worktree paths to avoid nesting worktrees
     # (e.g., when running from inside an existing worktree)
     repo_name = get_main_repo_name() or repo_root.name
-    gh_cli = detect_gh_cli(input_str)  # Pass URL to detect correct CLI for forks
 
     # Parse input
     issue_number: Optional[int] = None
     issue_owner: Optional[str] = None
     issue_repo: Optional[str] = None
+    issue_host: Optional[str] = None
     issue_type: Optional[str] = None
-    target_repo: Optional[str] = None  # owner/repo for gh commands (supports forks)
+    target_repo: Optional[str] = None  # [host/]owner/repo for gh commands
     jira_key: Optional[str] = None
     branch_name: Optional[str] = None
     issue_source = "github"
@@ -2932,38 +3225,54 @@ def run_here(input_str: str, description: Optional[str] = None):
     else:
         jira_key = None  # Reset if acli not available
 
-        # Try GitHub URL/number parsing
+        # Try GitHub URL first (overrides remote detection)
         parsed = parse_github_url(input_str)
         if parsed:
             issue_owner = parsed.owner
             issue_repo = parsed.repo
             issue_type = parsed.issue_type
             issue_number = parsed.number
-            # Use the URL's repo for all operations (supports forks)
-        elif input_str.isdigit():
-            issue_number = int(input_str)
-            issue_type = "issues"
-            # Get owner/repo from remote
-            try:
-                result = subprocess.run(
-                    ["git", "remote", "get-url", "origin"],
-                    capture_output=True, text=True, check=True
-                )
-                match = re.search(r'github(?:\.netflix)?\.(?:com|net)[:/]([^/]+)/([^/.\s]+)', result.stdout)
-                if match:
-                    issue_owner = match.group(1)
-                    issue_repo = match.group(2).replace('.git', '')
-            except subprocess.CalledProcessError:
-                pass
+            # Extract host from URL for target_repo prefix
+            url_host_match = re.match(r'https?://(?:www\.)?([^/]+)', input_str)
+            if url_host_match:
+                issue_host = url_host_match.group(1)
         else:
-            # Treat as feature description
-            description = input_str
+            # Support owner/name:N and host/owner/name:N inline prefixes
+            issue_token, inline_repo = parse_issue_arg(input_str)
+            # CLI --repo flag wins over inline prefix
+            effective_repo = repo_override or inline_repo
+
+            if issue_token.isdigit():
+                issue_number = int(issue_token)
+                issue_type = "issues"
+                # Resolve host/owner/repo from flag, env, or remotes
+                resolved = resolve_target_repo(
+                    gh_host=os.environ.get("GH_HOST"),
+                    explicit_repo=effective_repo,
+                )
+                if resolved:
+                    issue_host, issue_owner, issue_repo = resolved
+            elif effective_repo:
+                raise click.ClickException(
+                    f"--repo or 'repo:' prefix requires a numeric issue "
+                    f"number, got: {issue_token!r}"
+                )
+            else:
+                # Treat as feature description
+                description = input_str
 
         # Find or create branch for GitHub issue
         if issue_number:
             click.echo(f"Found GitHub {issue_type}: #{issue_number}")
-            # Build target repo string for gh commands (supports forks)
-            target_repo = f"{issue_owner}/{issue_repo}" if issue_owner and issue_repo else None
+            # Build target repo with host prefix so gh disambiguates correctly
+            if issue_owner and issue_repo:
+                if issue_host:
+                    target_repo = f"{issue_host}/{issue_owner}/{issue_repo}"
+                else:
+                    target_repo = f"{issue_owner}/{issue_repo}"
+
+            # Pick the gh binary based on the resolved host (not just origin)
+            gh_cli = detect_gh_cli(f"https://{issue_host}/" if issue_host else None)
 
             if issue_type == "pull":
                 # For PRs, fetch the branch name
@@ -2991,6 +3300,10 @@ def run_here(input_str: str, description: Optional[str] = None):
             # Feature branch
             branch_name = f"feature-{slugify(description)}"
             click.echo(f"Will create feature branch: {branch_name}")
+
+    # gh_cli for downstream code paths when we don't have a host yet
+    if 'gh_cli' not in locals():
+        gh_cli = detect_gh_cli(input_str)
 
     if not branch_name:
         raise click.ClickException("Could not determine branch name")
@@ -3050,10 +3363,13 @@ def run_here(input_str: str, description: Optional[str] = None):
     if issue_source == "jira" and jira_key:
         task_ref = f"JIRA issue {jira_key} (https://netflix.atlassian.net/browse/{jira_key})"
     elif issue_number and issue_owner and issue_repo:
-        if issue_type == "pull":
-            task_ref = f"GitHub PR https://github.com/{issue_owner}/{issue_repo}/pull/{issue_number}"
-        else:
-            task_ref = f"GitHub issue https://github.com/{issue_owner}/{issue_repo}/issues/{issue_number}"
+        host_for_url = issue_host or "github.com"
+        kind = "pull" if issue_type == "pull" else "issues"
+        label = "PR" if issue_type == "pull" else "issue"
+        task_ref = (
+            f"GitHub {label} https://{host_for_url}/{issue_owner}/"
+            f"{issue_repo}/{kind}/{issue_number}"
+        )
     elif issue_number:
         task_ref = f"Issue #{issue_number}"
     else:

--- a/work
+++ b/work
@@ -646,13 +646,15 @@ def parse_remote_url(url: str) -> Optional[tuple[str, str, str]]:
     url = url.strip()
 
     # HTTPS: https://host/owner/repo(.git)?
+    # Repo name may contain dots (e.g. `foo.bar`); only `.git` suffix or
+    # a trailing slash terminates the match.
     https_match = re.match(
-        r'https?://([^/]+)/([^/]+)/([^/.\s]+?)(?:\.git)?/?$',
+        r'https?://([^/]+)/([^/]+)/([^/\s]+?)(?:\.git)?/?$',
         url,
     )
     # SSH: git@host:owner/repo(.git)?
     ssh_match = re.match(
-        r'(?:ssh://)?git@([^:/]+)[:/]([^/]+)/([^/.\s]+?)(?:\.git)?/?$',
+        r'(?:ssh://)?git@([^:/]+)[:/]([^/]+)/([^/\s]+?)(?:\.git)?/?$',
         url,
     )
     match = https_match or ssh_match
@@ -1071,7 +1073,10 @@ def _build_work_invocation(
 ) -> str:
     """Build the ``work --here`` shell invocation, forwarding flags."""
     repo_flag = f" --repo {shlex.quote(repo_override)}" if repo_override else ""
-    return f"'{script_path}'{repo_flag} --here {shlex.quote(issue)}"
+    return (
+        f"{shlex.quote(str(script_path))}{repo_flag} "
+        f"--here {shlex.quote(issue)}"
+    )
 
 
 def spawn_iterm2(
@@ -1186,11 +1191,19 @@ def validate_issues_before_spawn(
 
         # Bare number or owner/name:N / host/owner/name:N
         issue_token, inline_repo = parse_issue_arg(raw)
-        if not issue_token.isdigit():
-            # Not a number and not URL/JIRA → description; skip
-            continue
-
         effective_repo = repo_override or inline_repo
+
+        if not issue_token.isdigit():
+            # A repo override with a non-numeric token is a user error —
+            # mirror the check in ``run_here`` so the spawn path fails
+            # here rather than silently later inside the new terminal tab.
+            if effective_repo:
+                raise click.ClickException(
+                    f"--repo or 'repo:' prefix requires a numeric issue "
+                    f"number, got: {issue_token!r}"
+                )
+            # Otherwise treat as a feature description; nothing to validate.
+            continue
         try:
             resolved = resolve_target_repo(
                 gh_host=gh_host, explicit_repo=effective_repo

--- a/work
+++ b/work
@@ -1087,6 +1087,16 @@ def _build_work_invocation(
     )
 
 
+def _escape_for_applescript(s: str) -> str:
+    """Escape a string for embedding in an AppleScript double-quoted literal.
+
+    ``shlex.quote`` output can contain ``"`` (e.g. ``'O'"'"'Brian'``),
+    which would prematurely close the AppleScript string. Backslashes
+    also need escaping because AppleScript treats ``\\`` as an escape.
+    """
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def spawn_iterm2(
     issue: str,
     script_path: Path,
@@ -1098,13 +1108,14 @@ def spawn_iterm2(
     env_str = f"{env_prefix} " if env_prefix else ""
     invocation = _build_work_invocation(issue, script_path, repo_override)
     cmd = f"cd {shlex.quote(str(cwd))} && {env_str}{invocation}"
+    cmd_for_applescript = _escape_for_applescript(cmd)
 
     applescript = f'''
 tell application "iTerm2"
     tell current window
         create tab with default profile
         tell current session
-            write text "{cmd}"
+            write text "{cmd_for_applescript}"
         end tell
     end tell
 end tell

--- a/work
+++ b/work
@@ -628,10 +628,15 @@ def parse_issue_arg(input_str: str) -> tuple[str, Optional[str]]:
     Parse issue argument with optional repo prefix.
     Returns (issue, repo) tuple where repo may be None.
     Supports: 42, repo:42, owner/repo:42, host/owner/repo:42, AIE-123
+
+    Only treats ``prefix:suffix`` as repo-scoped when the suffix is a
+    numeric issue number. This avoids misinterpreting feature
+    descriptions like ``"fix: the auth bug"`` as a repo prefix.
     """
     if ":" in input_str and not input_str.startswith("http"):
         repo, issue = input_str.split(":", 1)
-        return issue, repo
+        if issue.isdigit():
+            return issue, repo
     return input_str, None
 
 
@@ -724,7 +729,10 @@ def resolve_target_repo(
     if explicit_repo:
         parts = explicit_repo.strip("/").split("/")
         if len(parts) == 2:
-            return None, parts[0], parts[1]
+            # No host segment — fall back to GH_HOST if the caller set it,
+            # so an explicit repo combined with an explicit host still
+            # reaches the right API.
+            return gh_host, parts[0], parts[1]
         if len(parts) == 3:
             return parts[0], parts[1], parts[2]
         raise click.ClickException(


### PR DESCRIPTION
## Summary

Fixes #5 — when a repo has remotes on different hosts (e.g. `origin` on GHE, `upstream` on `github.com`) without `gh repo set-default`, `work 42` would silently resolve the issue against whichever remote `gh` happened to prefer. Workers would spawn against unrelated issues in a different repo, and the mismatch only surfaced later when PRs landed in the wrong place.

## What's fixed

- **Ambiguity is now a hard error**. If remotes span multiple hosts and there's no way to disambiguate, `work` bails with a listing of the conflicting remotes and the available escape hatches.
- **Upfront validation**. Before spawning any terminal tabs, each issue's title is fetched from its resolved repo. If any fail, `work` reports which ones and which repo it tried — no autonomy is burned on the wrong work.
- **`--repo [HOST/]OWNER/NAME` flag** on the top-level CLI. Pinned across all issues in a multi-issue invocation (`work --repo corp/proj 4 5 6 10 11 12`) and forwarded to spawned tabs.
- **`GH_HOST` is honored and forwarded**. When set, it picks the matching remote. The value is passed into spawned iTerm2 / Windows Terminal sessions so child `gh` calls use the same host.
- **Inline `owner/name:42` / `host/owner/name:42` prefix** now works in the spawn path (previously only recognized by worker-lookup commands).
- **`target_repo` includes the host prefix** when calling `gh --repo`, so gh can't re-resolve to the wrong host.

## Key implementation notes

- New `parse_remote_url`, `get_git_remotes`, and `resolve_target_repo` helpers in `work`. `get_git_remotes` reads raw URLs via `git config --get-regexp` so `url.<base>.insteadOf` rewrites don't mask the configured host.
- Host detection uses an **allowlist** (`github.com`, `github.netflix.net`, and subdomains of each) — lookalikes like `notgithub.com` or `github.com.attacker.net` are rejected.
- `parse_issue_arg` only splits on `:` when the suffix is numeric, so feature descriptions like `"fix: the auth bug"` aren't misparsed as repo-scoped.
- Spawn-command building uses `shlex.quote` throughout with an additional AppleScript-escape pass so single-quote characters in paths can't break the iTerm2 `write text` literal.

## Test plan

- [x] `uv run --extra test pytest tests/test_parsing.py` — 72 passing (added ~30 new tests covering `parse_remote_url`, `get_git_remotes`, `resolve_target_repo`, `validate_issues_before_spawn`, spawn invocation builders, AppleScript escaping, and `parse_issue_arg` edge cases).
- [x] `./work --help` — new examples surface `--repo` and `owner/name:42`.
- [x] Self-review via `./work --review` — APPROVED (multiple rounds of review + follow-up fixes).
- [x] `bdp-skills:llm-panel` (GPT-5.2 / Claude Opus 4.6 / Gemini 3.1 Pro) — 7.6/10 avg; actionable findings on host policy, dead fallback, and test boundary folded into the final commit.
- [ ] Manual smoke: re-run the original repro (`GH_HOST=github.netflix.net work 4 5 6 ...` in a multi-remote repo) and confirm workers land in the intended repo — requires your environment.

## Commits

Individual commits are structured as fix → iterative review follow-ups; they squash cleanly per repo convention.